### PR TITLE
[26.04_linux-nvidia-bos] UBUNTU: [Config] nvidia: Disable default CMA reservation

### DIFF
--- a/Documentation/admin-guide/kernel-parameters.txt
+++ b/Documentation/admin-guide/kernel-parameters.txt
@@ -8541,7 +8541,8 @@ Kernel parameters
         workqueue.default_affinity_scope=
 			Select the default affinity scope to use for unbound
 			workqueues. Can be one of "cpu", "smt", "cache",
-			"numa" and "system". Default is "cache". For more
+			"cache_shard", "numa" and "system". Default is
+			"cache_shard". For more
 			information, see the Affinity Scopes section in
 			Documentation/core-api/workqueue.rst.
 

--- a/Documentation/core-api/workqueue.rst
+++ b/Documentation/core-api/workqueue.rst
@@ -378,9 +378,9 @@ Affinity Scopes
 
 An unbound workqueue groups CPUs according to its affinity scope to improve
 cache locality. For example, if a workqueue is using the default affinity
-scope of "cache", it will group CPUs according to last level cache
-boundaries. A work item queued on the workqueue will be assigned to a worker
-on one of the CPUs which share the last level cache with the issuing CPU.
+scope of "cache_shard", it will group CPUs into sub-LLC shards. A work item
+queued on the workqueue will be assigned to a worker on one of the CPUs
+within the same shard as the issuing CPU.
 Once started, the worker may or may not be allowed to move outside the scope
 depending on the ``affinity_strict`` setting of the scope.
 
@@ -402,7 +402,13 @@ Workqueue currently supports the following affinity scopes.
 ``cache``
   CPUs are grouped according to cache boundaries. Which specific cache
   boundary is used is determined by the arch code. L3 is used in a lot of
-  cases. This is the default affinity scope.
+  cases.
+
+``cache_shard``
+  CPUs are grouped into sub-LLC shards of at most ``wq_cache_shard_size``
+  cores (default 8, tunable via the ``workqueue.cache_shard_size`` boot
+  parameter). Shards are always split on core (SMT group) boundaries.
+  This is the default affinity scope.
 
 ``numa``
   CPUs are grouped according to NUMA boundaries.

--- a/debian.nvidia-bos/config/annotations
+++ b/debian.nvidia-bos/config/annotations
@@ -45,7 +45,7 @@ CONFIG_ARM_LFA                                  note<'LP: #2138342'>
 CONFIG_ARM_SMMU_V3_IOMMUFD                      policy<{'arm64': 'y'}>
 CONFIG_ARM_SMMU_V3_IOMMUFD                      note<'LP: #2095028'>
 
-CONFIG_CMA_SIZE_MBYTES                          policy<{'amd64': '0', 'arm64': '32', 'arm64-nvidia-bos': '128', 'arm64-nvidia-bos-64k': '1024'}>
+CONFIG_CMA_SIZE_MBYTES                          policy<{'amd64': '0', 'arm64': '0'}>
 CONFIG_CMA_SIZE_MBYTES                          note<'LP: #2095028'>
 
 CONFIG_CORESIGHT                                policy<{'arm64': 'm'}>

--- a/drivers/fwctl/main.c
+++ b/drivers/fwctl/main.c
@@ -415,7 +415,7 @@ static void __exit fwctl_exit(void)
 	unregister_chrdev_region(fwctl_dev, FWCTL_MAX_DEVICES);
 }
 
-module_init(fwctl_init);
+subsys_initcall(fwctl_init);
 module_exit(fwctl_exit);
 MODULE_DESCRIPTION("fwctl device firmware access framework");
 MODULE_LICENSE("GPL");

--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -942,12 +942,8 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			if (gpio->soc->prefix)
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%s-P%s.%02x",
-						      gpio->soc->prefix, port->name, j);
-			else
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "P%s.%02x",
-						      port->name, j);
+			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
+					      gpio->soc->prefix ?: "", port->name, j);
 			if (!name)
 				return -ENOMEM;
 
@@ -1373,6 +1369,9 @@ static const struct tegra_gpio_soc tegra256_main_soc = {
 	.has_vm_support = true,
 };
 
+/* Macro to define GPIO name prefix with separator */
+#define TEGRA_GPIO_PREFIX(_x)	_x "-"
+
 #define TEGRA410_COMPUTE_GPIO_PORT(_name, _bank, _port, _pins)	\
 	TEGRA_GPIO_PORT(TEGRA410_COMPUTE, _name, _bank, _port, _pins)
 
@@ -1388,7 +1387,7 @@ static const struct tegra_gpio_soc tegra410_compute_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_compute_ports),
 	.ports = tegra410_compute_ports,
 	.name = "tegra410-gpio-compute",
-	.prefix = "COMPUTE",
+	.prefix = TEGRA_GPIO_PREFIX("COMPUTE"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };
@@ -1418,7 +1417,7 @@ static const struct tegra_gpio_soc tegra410_system_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_system_ports),
 	.ports = tegra410_system_ports,
 	.name = "tegra410-gpio-system",
-	.prefix = "SYSTEM",
+	.prefix = TEGRA_GPIO_PREFIX("SYSTEM"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };

--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -857,7 +857,7 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	struct device_node *np;
 	struct resource *res;
 	char **names;
-	int err;
+	int node, err;
 
 	gpio = devm_kzalloc(&pdev->dev, sizeof(*gpio), GFP_KERNEL);
 	if (!gpio)
@@ -937,13 +937,23 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	if (!names)
 		return -ENOMEM;
 
+	node = dev_to_node(&pdev->dev);
+
 	for (i = 0, offset = 0; i < gpio->soc->num_ports; i++) {
 		const struct tegra_gpio_port *port = &gpio->soc->ports[i];
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
-					      gpio->soc->prefix ?: "", port->name, j);
+			if (node >= 0)
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%d-%sP%s.%02x", node,
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
+			else
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%sP%s.%02x",
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
 			if (!name)
 				return -ENOMEM;
 

--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3784,6 +3784,19 @@ static int arm_smmu_def_domain_type(struct device *dev)
 		if (IS_HISI_PTT_DEVICE(pdev))
 			return IOMMU_DOMAIN_IDENTITY;
 
+		/*
+		 * ASPEED BMC devices behind an AST1150 PCIe-to-PCI bridge
+		 * receive DMA from BMC firmware using host physical addresses
+		 * that bypass the kernel DMA API.  Use identity mapping so
+		 * the SMMU passes these transactions through untranslated.
+		 */
+		if (pdev->bus->self &&
+		    (pdev->bus->self->dev_flags &
+		     PCI_DEV_FLAGS_PCI_BRIDGE_NO_ALIAS) &&
+		    pdev->bus->self->vendor == PCI_VENDOR_ID_ASPEED &&
+		    pdev->bus->self->device == 0x1150)
+			return IOMMU_DOMAIN_IDENTITY;
+
 		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA &&
 		    (pdev->device == 0x2E12 || pdev->device == 0x2E2A ||
 		     pdev->device == 0x2E2B))

--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3798,8 +3798,7 @@ static int arm_smmu_def_domain_type(struct device *dev)
 			return IOMMU_DOMAIN_IDENTITY;
 
 		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA &&
-		    (pdev->device == 0x2E12 || pdev->device == 0x2E2A ||
-		     pdev->device == 0x2E2B))
+		    pdev->device >= 0x2E00 && pdev->device <= 0x2E3F)
 			return IOMMU_DOMAIN_DMA;
 	}
 

--- a/drivers/net/ethernet/realtek/r8169_main.c
+++ b/drivers/net/ethernet/realtek/r8169_main.c
@@ -241,10 +241,8 @@ static const struct pci_device_id rtl8169_pci_tbl[] = {
 	{ 0x0001, 0x8168, PCI_ANY_ID, 0x2410 },
 	{ PCI_VDEVICE(REALTEK,	0x8125) },
 	{ PCI_VDEVICE(REALTEK,	0x8126) },
-	{ PCI_VDEVICE(REALTEK,	0x8127) },
 	{ PCI_VDEVICE(REALTEK,	0x3000) },
 	{ PCI_VDEVICE(REALTEK,	0x5000) },
-	{ PCI_VDEVICE(REALTEK,	0x0e10) },
 	{}
 };
 

--- a/drivers/nvme/host/Makefile
+++ b/drivers/nvme/host/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 ccflags-y				+= -I$(src)
-
+ccflags-y				+= -DCONFIG_NVFS
 obj-$(CONFIG_NVME_CORE)			+= nvme-core.o
 obj-$(CONFIG_BLK_DEV_NVME)		+= nvme.o
 obj-$(CONFIG_NVME_FABRICS)		+= nvme-fabrics.o
@@ -20,10 +20,11 @@ nvme-core-$(CONFIG_NVME_HWMON)		+= hwmon.o
 nvme-core-$(CONFIG_NVME_HOST_AUTH)	+= auth.o
 
 nvme-y					+= pci.o
-
+nvme-y					+= nvfs-dma.o
 nvme-fabrics-y				+= fabrics.o
 
 nvme-rdma-y				+= rdma.o
+nvme-rdma-y				+= nvfs-rdma.o
 
 nvme-fc-y				+= fc.o
 

--- a/drivers/nvme/host/nvfs-dma.c
+++ b/drivers/nvme/host/nvfs-dma.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#ifdef CONFIG_NVFS
+#define NVFS_USE_DMA_ITER_API
+#define MODULE_PREFIX nvme_v2
+#include "nvfs.h"
+
+struct nvfs_dma_rw_blk_iter_ops *nvfs_ops = NULL;
+
+atomic_t nvfs_shutdown = ATOMIC_INIT(1);
+
+DEFINE_PER_CPU(long, nvfs_n_ops);
+
+#define NVIDIA_FS_COMPAT_FT(ops) \
+	(NVIDIA_FS_CHECK_FT_BLK_DMA_MAP_ITER_START(ops) && NVIDIA_FS_CHECK_FT_BLK_DMA_MAP_ITER_NEXT(ops))
+
+// protected via nvfs_module_mutex
+int REGISTER_FUNC(struct nvfs_dma_rw_blk_iter_ops *ops)
+{
+	if (NVIDIA_FS_COMPAT_FT(ops)) {
+		nvfs_ops = ops;
+		atomic_set(&nvfs_shutdown, 0);
+		return 0;
+	} else
+		return -EOPNOTSUPP;
+
+}
+EXPORT_SYMBOL_GPL(REGISTER_FUNC);
+
+// protected via nvfs_module_mutex
+void UNREGISTER_FUNC(void)
+{
+	(void) atomic_cmpxchg(&nvfs_shutdown, 0, 1);
+	do {
+		msleep(NVFS_HOLD_TIME_MS);
+	} while(nvfs_count_ops());
+	nvfs_ops = NULL;
+}
+EXPORT_SYMBOL_GPL(UNREGISTER_FUNC);
+#endif

--- a/drivers/nvme/host/nvfs-dma.h
+++ b/drivers/nvme/host/nvfs-dma.h
@@ -1,0 +1,197 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef NVFS_DMA_H
+#define NVFS_DMA_H
+
+/* Forward declarations for functions from pci.c that we need */
+static blk_status_t nvme_pci_setup_data_prp(struct request *req,
+		struct blk_dma_iter *iter);
+static blk_status_t nvme_pci_setup_data_sgl(struct request *req,
+		struct blk_dma_iter *iter);
+static inline struct dma_pool *nvme_dma_pool(struct nvme_queue *nvmeq,
+		struct nvme_iod *iod);
+static inline dma_addr_t nvme_pci_first_desc_dma_addr(struct nvme_command *cmd);
+
+static inline bool nvme_nvfs_unmap_sgls(struct request *req)
+{
+	struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+	struct nvme_queue *nvmeq = req->mq_hctx->driver_data;
+	struct device *dma_dev = nvmeq->dev->dev;
+	unsigned int sqe_dma_len = le32_to_cpu(iod->cmd.common.dptr.sgl.length);
+	struct nvme_sgl_desc *sg_list = iod->descriptors[0];
+	enum dma_data_direction dir = rq_dma_dir(req);
+
+	/*
+	 * nr_descriptors == 0 means dma_pool_alloc failed before any SGL
+	 * entries were recorded; the first iter mapping is handled by
+	 * nvme_nvfs_map_data() directly, so nothing to unmap here.
+	 */
+	if (iod->nr_descriptors) {
+		unsigned int nr_entries = sqe_dma_len / sizeof(*sg_list), i;
+
+		for (i = 0; i < nr_entries; i++) {
+			nvfs_ops->nvfs_dma_unmap_page(dma_dev,
+					              iod->nvfs_cookie,
+						      le64_to_cpu(sg_list[i].addr),
+						      le32_to_cpu(sg_list[i].length),
+						      dir);
+		}
+	}
+
+	return true;
+}
+
+static inline bool nvme_nvfs_unmap_prps(struct request *req)
+{
+	struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+	struct nvme_queue *nvmeq = req->mq_hctx->driver_data;
+	struct device *dma_dev = nvmeq->dev->dev;
+	enum dma_data_direction dma_dir = rq_dma_dir(req);
+	unsigned int i;
+
+	/* Check if dma_vecs was allocated - if setup failed early, it might be NULL */
+	if (!iod->dma_vecs)
+		return true;
+
+	/* Unmap all DMA vectors - pass page pointer from dma_vecs */
+	for (i = 0; i < iod->nr_dma_vecs; i++) {
+		nvfs_ops->nvfs_dma_unmap_page(dma_dev,
+				              iod->nvfs_cookie,
+					      iod->dma_vecs[i].addr,
+					      iod->dma_vecs[i].len,
+				              dma_dir);
+	}
+
+	/* Free the dma_vecs mempool allocation */
+	mempool_free(iod->dma_vecs, nvmeq->dev->dmavec_mempool);
+	iod->dma_vecs = NULL;
+	iod->nr_dma_vecs = 0;
+
+	return true;
+}
+
+static inline void nvme_nvfs_free_descriptors(struct request *req)
+{
+	struct nvme_queue *nvmeq = req->mq_hctx->driver_data;
+	const int last_prp = NVME_CTRL_PAGE_SIZE / sizeof(__le64) - 1;
+	struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+	dma_addr_t dma_addr = nvme_pci_first_desc_dma_addr(&iod->cmd);
+	int i;
+
+	if (iod->nr_descriptors == 1) {
+		dma_pool_free(nvme_dma_pool(nvmeq, iod), iod->descriptors[0],
+				dma_addr);
+		return;
+	}
+
+	for (i = 0; i < iod->nr_descriptors; i++) {
+		__le64 *prp_list = iod->descriptors[i];
+		dma_addr_t next_dma_addr = le64_to_cpu(prp_list[last_prp]);
+
+		dma_pool_free(nvmeq->descriptor_pools.large, prp_list,
+				dma_addr);
+		dma_addr = next_dma_addr;
+	}
+}
+
+static inline bool nvme_nvfs_unmap_data(struct request *req)
+{
+	struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+	bool ret;
+
+	/* Check if this was an NVFS I/O by checking the IOD_NVFS_IO flag */
+	if (!(iod->flags & IOD_NVFS_IO))
+		return false;
+
+	/* Clear the NVFS flag */
+	iod->flags &= ~IOD_NVFS_IO;
+
+	/* Call appropriate unmap function based on command type */
+	if (nvme_pci_cmd_use_sgl(&iod->cmd))
+		ret = nvme_nvfs_unmap_sgls(req);
+	else
+		ret = nvme_nvfs_unmap_prps(req);
+
+	if (iod->nr_descriptors)
+		nvme_nvfs_free_descriptors(req);
+
+	nvfs_put_ops();
+	return ret;
+}
+
+static inline blk_status_t nvme_nvfs_map_data(struct request *req,
+		bool *is_nvfs_io)
+{
+	struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+	struct nvme_queue *nvmeq = req->mq_hctx->driver_data;
+	struct nvme_dev *dev = nvmeq->dev;
+	struct device *dma_dev = nvmeq->dev->dev;
+	enum nvme_use_sgl use_sgl = nvme_pci_use_sgls(dev, req);
+	struct blk_dma_iter iter;
+	blk_status_t ret = BLK_STS_RESOURCE;
+
+	*is_nvfs_io = false;
+
+	/* Check integrity and try to get nvfs_ops */
+	if (blk_integrity_rq(req) || !nvfs_get_ops()) {
+		return ret;
+	}
+
+	/* Initialize total_len for this request */
+	iod->total_len = 0;
+
+	if (!nvfs_ops->nvfs_blk_rq_dma_map_iter_start(req, dma_dev,
+						       &iod->dma_state, &iter, &iod->nvfs_cookie)) {
+		nvfs_put_ops();
+		if (iter.status == BLK_STS_IOERR) {
+			/* GPU DMA error — do not fall through to CPU path */
+			*is_nvfs_io = true;
+			ret = iter.status;
+		}
+		/* else: CPU page, let caller fall through to CPU path */
+		return ret;
+	}
+
+	/* NVFS can handle this request, set the flag */
+	*is_nvfs_io = true;
+	iod->flags |= IOD_NVFS_IO;
+
+	if (use_sgl == SGL_FORCED ||
+	    (use_sgl == SGL_SUPPORTED &&
+	     (sgl_threshold && nvme_pci_avg_seg_size(req) >= sgl_threshold)))
+		ret = nvme_pci_setup_data_sgl(req, &iter);
+	else
+		ret = nvme_pci_setup_data_prp(req, &iter);
+
+	/* If setup failed, cleanup: unmap DMA, clear flag, release ops */
+	if (ret != BLK_STS_OK) {
+		/*
+		 * If setup failed before any mappings were tracked (dma_vecs is
+		 * NULL for PRP, or nr_descriptors is 0 for SGL), the first page
+		 * mapped by nvfs_blk_rq_dma_map_iter_start() won't be covered by
+		 * nvme_nvfs_unmap_data(). Unmap it directly using iter.
+		 */
+		bool early_fail = nvme_pci_cmd_use_sgl(&iod->cmd) ?
+			!iod->nr_descriptors : !iod->dma_vecs;
+		if (early_fail)
+			nvfs_ops->nvfs_dma_unmap_page(dma_dev, iod->nvfs_cookie,
+					iter.addr, iter.len, rq_dma_dir(req));
+		nvme_nvfs_unmap_data(req);
+	}
+
+	return ret;
+}
+
+#endif /* NVFS_DMA_H */

--- a/drivers/nvme/host/nvfs-rdma.c
+++ b/drivers/nvme/host/nvfs-rdma.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifdef CONFIG_NVFS
+#define MODULE_PREFIX nvme_rdma_v1
+#include "nvfs.h"
+
+struct nvfs_dma_rw_ops *nvfs_ops;
+
+atomic_t nvfs_shutdown = ATOMIC_INIT(1);
+
+DEFINE_PER_CPU(long, nvfs_n_ops);
+
+// must have for compatability
+#define NVIDIA_FS_COMPAT_FT(ops) \
+	(NVIDIA_FS_CHECK_FT_SGLIST_PREP(ops) && NVIDIA_FS_CHECK_FT_SGLIST_DMA(ops))
+
+// protected via nvfs_module_mutex
+int REGISTER_FUNC(struct nvfs_dma_rw_ops *ops)
+{
+	if (NVIDIA_FS_COMPAT_FT(ops)) {
+		nvfs_ops = ops;
+		atomic_set(&nvfs_shutdown, 0);
+		return 0;
+	} else
+		return -EOPNOTSUPP;
+
+}
+EXPORT_SYMBOL_GPL(REGISTER_FUNC);
+
+// protected via nvfs_module_mutex
+void UNREGISTER_FUNC(void)
+{
+	(void) atomic_cmpxchg(&nvfs_shutdown, 0, 1);
+	do {
+		msleep(NVFS_HOLD_TIME_MS);
+	} while(nvfs_count_ops());
+	nvfs_ops = NULL;
+}
+EXPORT_SYMBOL_GPL(UNREGISTER_FUNC);
+#endif

--- a/drivers/nvme/host/nvfs-rdma.h
+++ b/drivers/nvme/host/nvfs-rdma.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef NVFS_RDMA_H
+#define NVFS_RDMA_H
+
+static bool nvme_rdma_nvfs_unmap_data(struct ib_device *ibdev,
+		struct request *rq)
+
+{
+	struct nvme_rdma_request *req = blk_mq_rq_to_pdu(rq);
+	enum dma_data_direction dma_dir = rq_dma_dir(rq);
+	int count;
+
+	if (!blk_integrity_rq(rq) && nvfs_ops != NULL) {
+		count = nvfs_ops->nvfs_dma_unmap_sg(ibdev->dma_device, req->data_sgl.sg_table.sgl, req->data_sgl.nents,
+				dma_dir);
+		if (count) {
+			nvfs_put_ops();
+			sg_free_table_chained(&req->data_sgl.sg_table, NVME_INLINE_SG_CNT);
+			return true;
+		}
+	}
+	return false;
+}
+
+static int nvme_rdma_nvfs_map_data(struct ib_device *ibdev, struct request *rq, bool *is_nvfs_io, int* count)
+{
+	struct nvme_rdma_request *req = blk_mq_rq_to_pdu(rq);
+	enum dma_data_direction dma_dir = rq_dma_dir(rq);
+	int ret = 0;
+
+	*is_nvfs_io = false;
+	*count = 0;
+	if (!blk_integrity_rq(rq) && nvfs_get_ops()) {
+
+		// associates bio pages to scatterlist
+		*count = nvfs_ops->nvfs_blk_rq_map_sg(rq->q, rq , req->data_sgl.sg_table.sgl);
+		if (!*count) {
+			nvfs_put_ops();
+			return 0; // fall to cpu path
+		}
+
+		*is_nvfs_io = true;
+		if (unlikely((*count == NVFS_IO_ERR))) {
+			nvfs_put_ops();
+			pr_err("%s: failed to map sg_nents=:%d\n", __func__, req->data_sgl.nents);
+			return -EIO;
+		}
+		req->data_sgl.nents = *count;
+
+		*count = nvfs_ops->nvfs_dma_map_sg_attrs(ibdev->dma_device,
+				req->data_sgl.sg_table.sgl,
+				req->data_sgl.nents,
+				dma_dir,
+				DMA_ATTR_NO_WARN);
+
+		if (unlikely((*count == NVFS_IO_ERR))) {
+			nvfs_put_ops();
+			return -EIO;
+		}
+
+		if (unlikely(*count == NVFS_CPU_REQ)) {
+			nvfs_put_ops();
+			return -EIO;
+		}
+
+		return ret;
+	}
+
+	// Fall to CPU path
+	return 0;
+}
+
+#endif

--- a/drivers/nvme/host/nvfs.h
+++ b/drivers/nvme/host/nvfs.h
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#ifndef NVFS_H
+#define NVFS_H
+
+#include <linux/types.h>
+#include <linux/delay.h>
+#include <linux/blkdev.h>
+#include <linux/cpumask.h>
+#include <linux/scatterlist.h>
+#include <linux/percpu-defs.h>
+#include <linux/dma-direction.h>
+
+/* Forward declarations */
+struct blk_dma_iter;
+struct dma_iova_state;
+
+#define REGSTR2(x) x##_register_nvfs_dma_ops
+#define REGSTR(x)  REGSTR2(x)
+
+#define UNREGSTR2(x) x##_unregister_nvfs_dma_ops
+#define UNREGSTR(x)  UNREGSTR2(x)
+
+#define REGISTER_FUNC REGSTR(MODULE_PREFIX)
+#define UNREGISTER_FUNC UNREGSTR(MODULE_PREFIX)
+
+#define NVFS_IO_ERR                    -1
+#define NVFS_CPU_REQ                   -2
+
+#define NVFS_HOLD_TIME_MS 1000
+
+#ifdef NVFS_USE_DMA_ITER_API
+extern struct nvfs_dma_rw_blk_iter_ops *nvfs_ops;
+#else
+extern struct nvfs_dma_rw_ops *nvfs_ops;
+#endif
+
+extern atomic_t nvfs_shutdown;
+
+DECLARE_PER_CPU(long, nvfs_n_ops);
+
+static inline long nvfs_count_ops(void)
+{
+	int i;
+	long sum = 0;
+	for_each_possible_cpu(i)
+		sum += per_cpu(nvfs_n_ops, i);
+	return sum;
+}
+
+static inline bool nvfs_get_ops(void)
+{
+	if (nvfs_ops && !atomic_read(&nvfs_shutdown)) {
+		this_cpu_inc(nvfs_n_ops);
+		return true;
+	}
+	return false;
+}
+
+static inline void nvfs_put_ops(void)
+{
+	this_cpu_dec(nvfs_n_ops);
+}
+
+
+struct nvfs_dma_rw_blk_iter_ops {
+	unsigned long long ft_bmap; // feature bitmap
+
+	int (*nvfs_blk_rq_dma_map_iter_start) (struct request *req,
+			struct device *dma_dev,
+			struct dma_iova_state *state,
+			struct blk_dma_iter *iter,
+			void **cookie);
+
+	int (*nvfs_blk_rq_dma_map_iter_next) (struct request *req,
+			struct device *dma_dev,
+			struct dma_iova_state *state,
+			struct blk_dma_iter *iter);
+
+	int (*nvfs_dma_unmap_page) (struct device *device,
+			void* cookie,
+			dma_addr_t addr,
+			size_t size,
+			enum dma_data_direction dir);
+
+	bool (*nvfs_is_gpu_page) (struct page *page);
+
+	unsigned int (*nvfs_gpu_index) (struct page *page);
+
+	unsigned int (*nvfs_device_priority) (struct device *dev, unsigned int gpu_index);
+
+};
+
+struct nvfs_dma_rw_ops {
+	unsigned long long ft_bmap; // feature bitmap
+
+	int (*nvfs_blk_rq_map_sg) (struct request_queue *q,
+			struct request *req,
+			struct scatterlist *sglist);
+
+	int (*nvfs_dma_map_sg_attrs) (struct device *device,
+			struct scatterlist *sglist,
+			int nents,
+			enum dma_data_direction dma_dir,
+			unsigned long attrs);
+
+	int (*nvfs_dma_unmap_sg)  (struct device *device,
+			struct scatterlist *sglist,
+			int nents,
+			enum dma_data_direction dma_dir);
+
+	bool (*nvfs_is_gpu_page) (struct page *page);
+
+	unsigned int (*nvfs_gpu_index) (struct page *page);
+
+	unsigned int (*nvfs_device_priority) (struct device *dev, unsigned int gpu_index);
+};
+
+// feature list for dma_ops, values indicate bit pos
+enum ft_bits {
+	nvfs_ft_prep_sglist              = 1ULL << 0,
+	nvfs_ft_map_sglist               = 1ULL << 1,
+	nvfs_ft_is_gpu_page              = 1ULL << 2,
+	nvfs_ft_device_priority          = 1ULL << 3,
+	nvfs_ft_blk_dma_map_iter_start   = 1ULL << 5,
+	nvfs_ft_blk_dma_map_iter_next    = 1ULL << 6,
+};
+
+// check features for use in registration with vendor drivers
+#define NVIDIA_FS_CHECK_FT_SGLIST_PREP(ops)               ((ops)->ft_bmap & nvfs_ft_prep_sglist)
+#define NVIDIA_FS_CHECK_FT_SGLIST_DMA(ops)                ((ops)->ft_bmap & nvfs_ft_map_sglist)
+#define NVIDIA_FS_CHECK_FT_GPU_PAGE(ops)                  ((ops)->ft_bmap & nvfs_ft_is_gpu_page)
+#define NVIDIA_FS_CHECK_FT_DEVICE_PRIORITY(ops)           ((ops)->ft_bmap & nvfs_ft_device_priority)
+#define NVIDIA_FS_CHECK_FT_BLK_DMA_MAP_ITER_START(ops)    ((ops)->ft_bmap & nvfs_ft_blk_dma_map_iter_start)
+#define NVIDIA_FS_CHECK_FT_BLK_DMA_MAP_ITER_NEXT(ops)     ((ops)->ft_bmap & nvfs_ft_blk_dma_map_iter_next)
+
+#ifdef NVFS_USE_DMA_ITER_API
+int REGISTER_FUNC(struct nvfs_dma_rw_blk_iter_ops *ops);
+#else
+int REGISTER_FUNC(struct nvfs_dma_rw_ops *ops);
+#endif
+
+void UNREGISTER_FUNC(void);
+
+#endif /* NVFS_H */

--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -30,12 +30,25 @@
 
 #include "trace.h"
 #include "nvme.h"
+#ifdef CONFIG_NVFS
+#define NVFS_USE_DMA_ITER_API
+#include "nvfs.h"
+#endif
 
 #define SQ_SIZE(q)	((q)->q_depth << (q)->sqes)
 #define CQ_SIZE(q)	((q)->q_depth * sizeof(struct nvme_completion))
 
 /* Optimisation for I/Os between 4k and 128k */
 #define NVME_SMALL_POOL_SIZE	256
+
+#ifdef CONFIG_NVFS
+/* GPU physical pages are minimum 64K. Worst-case SGL entries with misalignment:
+ * ceil(payload/64K) + 1. Safe payload for small pool = (entries - 1) * 64K,
+ * where entries = NVME_SMALL_POOL_SIZE / sizeof(struct nvme_sgl_desc). */
+#define NVFS_GPU_PAGE_SIZE		(64UL * 1024)
+#define NVFS_SMALL_POOL_PAYLOAD \
+	((NVME_SMALL_POOL_SIZE / sizeof(struct nvme_sgl_desc) - 1) * NVFS_GPU_PAGE_SIZE)
+#endif
 
 /*
  * Arbitrary upper bound.
@@ -418,6 +431,11 @@ enum nvme_iod_flags {
 
 	/* Metadata using non-coalesced MPTR */
 	IOD_SINGLE_META_SEGMENT	= 1U << 7,
+
+#ifdef CONFIG_NVFS
+	/* NVFS GPU Direct Storage I/O */
+	IOD_NVFS_IO		= 1U << 31,
+#endif
 };
 
 struct nvme_dma_vec {
@@ -431,7 +449,11 @@ struct nvme_dma_vec {
 struct nvme_iod {
 	struct nvme_request req;
 	struct nvme_command cmd;
+#ifdef CONFIG_NVFS
+	u32 flags;
+#else
 	u8 flags;
+#endif
 	u8 nr_descriptors;
 
 	size_t total_len;
@@ -444,6 +466,9 @@ struct nvme_iod {
 	size_t meta_total_len;
 	struct dma_iova_state meta_dma_state;
 	struct nvme_sgl_desc *meta_descriptor;
+#ifdef CONFIG_NVFS
+	void *nvfs_cookie;
+#endif
 };
 
 static inline unsigned int nvme_dbbuf_size(struct nvme_dev *dev)
@@ -924,6 +949,10 @@ static void nvme_unmap_metadata(struct request *req)
 			      iod->meta_descriptor, iod->meta_dma);
 }
 
+#ifdef CONFIG_NVFS
+#include "nvfs-dma.h"
+#endif
+
 static void nvme_unmap_data(struct request *req)
 {
 	enum pci_p2pdma_map_type map = PCI_P2PDMA_MAP_NONE;
@@ -931,6 +960,12 @@ static void nvme_unmap_data(struct request *req)
 	struct nvme_queue *nvmeq = req->mq_hctx->driver_data;
 	struct device *dma_dev = nvmeq->dev->dev;
 	unsigned int attrs = 0;
+
+#ifdef CONFIG_NVFS
+	/* Check if this was an NVFS I/O and handle unmapping */
+	if (nvme_nvfs_unmap_data(req))
+		return;
+#endif
 
 	if (iod->flags & IOD_SINGLE_SEGMENT) {
 		static_assert(offsetof(union nvme_data_ptr, prp1) ==
@@ -991,6 +1026,20 @@ static bool nvme_pci_prp_iter_next(struct request *req, struct device *dma_dev,
 {
 	if (iter->len)
 		return true;
+#ifdef CONFIG_NVFS
+	{
+		struct nvme_iod *iod = blk_mq_rq_to_pdu(req);
+		if (iod->flags & IOD_NVFS_IO) {
+			if (!nvfs_ops->nvfs_blk_rq_dma_map_iter_next(req, dma_dev,
+						&iod->dma_state, iter))
+				return false;
+			iod->dma_vecs[iod->nr_dma_vecs].addr = iter->addr;
+			iod->dma_vecs[iod->nr_dma_vecs].len = iter->len;
+			iod->nr_dma_vecs++;
+			return true;
+		}
+	}
+#endif
 	if (!blk_rq_dma_map_iter_next(req, dma_dev, iter))
 		return false;
 	return nvme_pci_prp_save_mapping(req, dma_dev, iter);
@@ -1006,6 +1055,16 @@ static blk_status_t nvme_pci_setup_data_prp(struct request *req,
 	unsigned int prp_len, i;
 	__le64 *prp_list;
 
+#ifdef CONFIG_NVFS
+	if (iod->flags & IOD_NVFS_IO) {
+		iod->dma_vecs = mempool_alloc(nvmeq->dev->dmavec_mempool, GFP_ATOMIC);
+		if (!iod->dma_vecs)
+			return BLK_STS_RESOURCE;
+		iod->dma_vecs[0].addr = iter->addr;
+		iod->dma_vecs[0].len = iter->len;
+		iod->nr_dma_vecs = 1;
+	} else
+#endif
 	if (!nvme_pci_prp_save_mapping(req, nvmeq->dev->dev, iter))
 		return iter->status;
 
@@ -1104,6 +1163,11 @@ done:
 	 */
 	iod->cmd.common.dptr.prp1 = cpu_to_le64(prp1_dma);
 	iod->cmd.common.dptr.prp2 = cpu_to_le64(prp2_dma);
+#ifdef CONFIG_NVFS
+	/* For NVFS, don't call nvme_unmap_data - cleanup happens in nvme_nvfs_unmap_data */
+	if (iod->flags & IOD_NVFS_IO)
+		return iter->status;
+#endif
 	if (unlikely(iter->status))
 		nvme_unmap_data(req);
 	return iter->status;
@@ -1144,12 +1208,34 @@ static blk_status_t nvme_pci_setup_data_sgl(struct request *req,
 	/* set the transfer type as SGL */
 	iod->cmd.common.flags = NVME_CMD_SGL_METABUF;
 
-	if (entries == 1 || blk_rq_dma_map_coalesce(&iod->dma_state)) {
-		nvme_pci_sgl_set_data(&iod->cmd.common.dptr.sgl, iter);
-		iod->total_len += iter->len;
-		return BLK_STS_OK;
+#ifdef CONFIG_NVFS
+	if (!(iod->flags & IOD_NVFS_IO))
+#endif
+	{
+		if (entries == 1 || blk_rq_dma_map_coalesce(&iod->dma_state)) {
+			nvme_pci_sgl_set_data(&iod->cmd.common.dptr.sgl, iter);
+			iod->total_len += iter->len;
+			return BLK_STS_OK;
+		}
 	}
 
+#ifdef CONFIG_NVFS
+	if (iod->flags & IOD_NVFS_IO) {
+		/*
+		 * blk_rq_nr_phys_segments() reflects shadow buffer contiguity,
+		 * not GPU physical segments. GPU pages are 64K minimum; worst-case
+		 * entries with misalignment = ceil(payload/64K) + 1.
+		 * Small pool (16 entries) is safe for payload < NVFS_SMALL_POOL_PAYLOAD.
+		 * Large pool capacity = NVME_CTRL_PAGE_SIZE / sizeof(*sg_list) = 256.
+		 */
+		if (blk_rq_payload_bytes(req) < NVFS_SMALL_POOL_PAYLOAD) {
+			entries = NVME_SMALL_POOL_SIZE / sizeof(*sg_list);
+			iod->flags |= IOD_SMALL_DESCRIPTOR;
+		} else {
+			entries = NVME_CTRL_PAGE_SIZE / sizeof(*sg_list);
+		}
+	} else
+#endif
 	if (entries <= NVME_SMALL_POOL_SIZE / sizeof(*sg_list))
 		iod->flags |= IOD_SMALL_DESCRIPTOR;
 
@@ -1166,9 +1252,21 @@ static blk_status_t nvme_pci_setup_data_sgl(struct request *req,
 		}
 		nvme_pci_sgl_set_data(&sg_list[mapped++], iter);
 		iod->total_len += iter->len;
-	} while (blk_rq_dma_map_iter_next(req, nvmeq->dev->dev, iter));
+	} while (
+#ifdef CONFIG_NVFS
+		(iod->flags & IOD_NVFS_IO) ?
+			(mapped < entries &&
+			 nvfs_ops->nvfs_blk_rq_dma_map_iter_next(req, nvmeq->dev->dev,
+					&iod->dma_state, iter)) :
+#endif
+		blk_rq_dma_map_iter_next(req, nvmeq->dev->dev, iter));
 
 	nvme_pci_sgl_set_seg(&iod->cmd.common.dptr.sgl, sgl_dma, mapped);
+#ifdef CONFIG_NVFS
+	/* For NVFS, don't call nvme_unmap_data - cleanup happens in nvme_nvfs_unmap_data */
+	if (iod->flags & IOD_NVFS_IO)
+		return iter->status;
+#endif
 	if (unlikely(iter->status))
 		nvme_unmap_data(req);
 	return iter->status;
@@ -1222,6 +1320,12 @@ static blk_status_t nvme_map_data(struct request *req)
 	struct blk_dma_iter iter;
 	blk_status_t ret;
 
+#ifdef CONFIG_NVFS
+	bool is_nvfs_io = false;
+	ret = nvme_nvfs_map_data(req, &is_nvfs_io);
+	if (is_nvfs_io)
+		return ret;
+#endif
 	/*
 	 * Try to skip the DMA iterator for single segment requests, as that
 	 * significantly improves performances for small I/O sizes.

--- a/drivers/nvme/host/rdma.c
+++ b/drivers/nvme/host/rdma.c
@@ -27,6 +27,9 @@
 #include "nvme.h"
 #include "fabrics.h"
 
+#ifdef CONFIG_NVFS
+#include "nvfs.h"
+#endif
 
 #define NVME_RDMA_CM_TIMEOUT_MS		3000		/* 3 second */
 
@@ -1212,6 +1215,9 @@ static int nvme_rdma_inv_rkey(struct nvme_rdma_queue *queue,
 	return ib_post_send(queue->qp, &wr, NULL);
 }
 
+#ifdef CONFIG_NVFS
+#include "nvfs-rdma.h"
+#endif
 static void nvme_rdma_dma_unmap_req(struct ib_device *ibdev, struct request *rq)
 {
 	struct nvme_rdma_request *req = blk_mq_rq_to_pdu(rq);
@@ -1222,6 +1228,11 @@ static void nvme_rdma_dma_unmap_req(struct ib_device *ibdev, struct request *rq)
 		sg_free_table_chained(&req->metadata_sgl->sg_table,
 				      NVME_INLINE_METADATA_SG_CNT);
 	}
+
+#ifdef CONFIG_NVFS
+	if (nvme_rdma_nvfs_unmap_data(ibdev, rq))
+		return;
+#endif
 
 	ib_dma_unmap_sg(ibdev, req->data_sgl.sg_table.sgl, req->data_sgl.nents,
 			rq_dma_dir(rq));
@@ -1476,6 +1487,17 @@ static int nvme_rdma_dma_map_req(struct ib_device *ibdev, struct request *rq,
 	if (ret)
 		return -ENOMEM;
 
+#ifdef CONFIG_NVFS
+	{
+		bool is_nvfs_io = false;
+		ret = nvme_rdma_nvfs_map_data(ibdev, rq, &is_nvfs_io, count);
+		if (is_nvfs_io) {
+			if (ret)
+				goto out_free_table;
+			return 0;
+		}
+	}
+#endif
 	req->data_sgl.nents = blk_rq_map_sg(rq, req->data_sgl.sg_table.sgl);
 
 	*count = ib_dma_map_sg(ibdev, req->data_sgl.sg_table.sgl,

--- a/drivers/pci/npem.c
+++ b/drivers/pci/npem.c
@@ -504,7 +504,7 @@ static int pci_npem_set_led_classdev(struct npem *npem, struct npem_led *nled)
 	led->brightness_get = brightness_get;
 	led->max_brightness = 1;
 	led->default_trigger = "none";
-	led->flags = 0;
+	led->flags = LED_HW_PLUGGABLE;
 
 	ret = led_classdev_register(&npem->dev->dev, led);
 	if (ret)

--- a/drivers/tty/serial/8250/8250_mtk.c
+++ b/drivers/tty/serial/8250/8250_mtk.c
@@ -19,6 +19,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/tty.h>
 #include <linux/tty_flip.h>
+#include <linux/units.h>
 
 #include "8250.h"
 
@@ -521,6 +522,7 @@ static int mtk8250_probe(struct platform_device *pdev)
 	struct mtk8250_data *data;
 	struct resource *regs;
 	int irq, err;
+	struct fwnode_handle *fwnode = dev_fwnode(&pdev->dev);
 
 	irq = platform_get_irq(pdev, 0);
 	if (irq < 0)
@@ -543,12 +545,13 @@ static int mtk8250_probe(struct platform_device *pdev)
 
 	data->clk_count = 0;
 
-	if (pdev->dev.of_node) {
+	if (is_of_node(fwnode)) {
 		err = mtk8250_probe_of(pdev, &uart.port, data);
 		if (err)
 			return err;
-	} else
+	} else if (!fwnode) {
 		return -ENODEV;
+	}
 
 	spin_lock_init(&uart.port.lock);
 	uart.port.mapbase = regs->start;
@@ -564,14 +567,18 @@ static int mtk8250_probe(struct platform_device *pdev)
 	uart.port.startup = mtk8250_startup;
 	uart.port.set_termios = mtk8250_set_termios;
 	uart.port.uartclk = clk_get_rate(data->uart_clk);
+	if (!uart.port.uartclk)
+		uart.port.uartclk = 26 * HZ_PER_MHZ;
 #ifdef CONFIG_SERIAL_8250_DMA
 	if (data->dma)
 		uart.dma = data->dma;
 #endif
 
-	/* Disable Rate Fix function */
-	writel(0x0, uart.port.membase +
+	if (is_of_node(fwnode)) {
+		/* Disable Rate Fix function */
+		writel(0x0, uart.port.membase +
 			(MTK_UART_RATE_FIX << uart.port.regshift));
+	}
 
 	platform_set_drvdata(pdev, data);
 
@@ -649,11 +656,19 @@ static const struct of_device_id mtk8250_of_match[] = {
 };
 MODULE_DEVICE_TABLE(of, mtk8250_of_match);
 
+static const struct acpi_device_id mtk8250_acpi_match[] = {
+	{ "MTKI0511" },
+	{ "NVDA0240" },
+	{}
+};
+MODULE_DEVICE_TABLE(acpi, mtk8250_acpi_match);
+
 static struct platform_driver mtk8250_platform_driver = {
 	.driver = {
 		.name		= "mt6577-uart",
 		.pm		= &mtk8250_pm_ops,
 		.of_match_table	= mtk8250_of_match,
+		.acpi_match_table = mtk8250_acpi_match,
 	},
 	.probe			= mtk8250_probe,
 	.remove			= mtk8250_remove,

--- a/drivers/tty/serial/8250/8250_mtk.c
+++ b/drivers/tty/serial/8250/8250_mtk.c
@@ -19,7 +19,6 @@
 #include <linux/dma-mapping.h>
 #include <linux/tty.h>
 #include <linux/tty_flip.h>
-#include <linux/units.h>
 
 #include "8250.h"
 
@@ -522,7 +521,6 @@ static int mtk8250_probe(struct platform_device *pdev)
 	struct mtk8250_data *data;
 	struct resource *regs;
 	int irq, err;
-	struct fwnode_handle *fwnode = dev_fwnode(&pdev->dev);
 
 	irq = platform_get_irq(pdev, 0);
 	if (irq < 0)
@@ -545,13 +543,12 @@ static int mtk8250_probe(struct platform_device *pdev)
 
 	data->clk_count = 0;
 
-	if (is_of_node(fwnode)) {
+	if (pdev->dev.of_node) {
 		err = mtk8250_probe_of(pdev, &uart.port, data);
 		if (err)
 			return err;
-	} else if (!fwnode) {
+	} else
 		return -ENODEV;
-	}
 
 	spin_lock_init(&uart.port.lock);
 	uart.port.mapbase = regs->start;
@@ -567,18 +564,14 @@ static int mtk8250_probe(struct platform_device *pdev)
 	uart.port.startup = mtk8250_startup;
 	uart.port.set_termios = mtk8250_set_termios;
 	uart.port.uartclk = clk_get_rate(data->uart_clk);
-	if (!uart.port.uartclk)
-		uart.port.uartclk = 26 * HZ_PER_MHZ;
 #ifdef CONFIG_SERIAL_8250_DMA
 	if (data->dma)
 		uart.dma = data->dma;
 #endif
 
-	if (is_of_node(fwnode)) {
-		/* Disable Rate Fix function */
-		writel(0x0, uart.port.membase +
+	/* Disable Rate Fix function */
+	writel(0x0, uart.port.membase +
 			(MTK_UART_RATE_FIX << uart.port.regshift));
-	}
 
 	platform_set_drvdata(pdev, data);
 
@@ -656,18 +649,11 @@ static const struct of_device_id mtk8250_of_match[] = {
 };
 MODULE_DEVICE_TABLE(of, mtk8250_of_match);
 
-static const struct acpi_device_id mtk8250_acpi_match[] = {
-	{ "MTKI0511" },
-	{}
-};
-MODULE_DEVICE_TABLE(acpi, mtk8250_acpi_match);
-
 static struct platform_driver mtk8250_platform_driver = {
 	.driver = {
 		.name		= "mt6577-uart",
 		.pm		= &mtk8250_pm_ops,
 		.of_match_table	= mtk8250_of_match,
-		.acpi_match_table = mtk8250_acpi_match,
 	},
 	.probe			= mtk8250_probe,
 	.remove			= mtk8250_remove,

--- a/include/linux/workqueue.h
+++ b/include/linux/workqueue.h
@@ -131,7 +131,7 @@ struct rcu_work {
 enum wq_affn_scope {
 	WQ_AFFN_DFL,			/* use system default */
 	WQ_AFFN_CPU,			/* one pod per CPU */
-	WQ_AFFN_SMT,			/* one pod poer SMT */
+	WQ_AFFN_SMT,			/* one pod per SMT */
 	WQ_AFFN_CACHE,			/* one pod per LLC */
 	WQ_AFFN_NUMA,			/* one pod per NUMA node */
 	WQ_AFFN_SYSTEM,			/* one pod across the whole system */

--- a/include/linux/workqueue.h
+++ b/include/linux/workqueue.h
@@ -133,6 +133,7 @@ enum wq_affn_scope {
 	WQ_AFFN_CPU,			/* one pod per CPU */
 	WQ_AFFN_SMT,			/* one pod per SMT */
 	WQ_AFFN_CACHE,			/* one pod per LLC */
+	WQ_AFFN_CACHE_SHARD,		/* synthetic sub-LLC shards */
 	WQ_AFFN_NUMA,			/* one pod per NUMA node */
 	WQ_AFFN_SYSTEM,			/* one pod across the whole system */
 

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -449,7 +449,7 @@ static bool wq_topo_initialized __read_mostly = false;
 static struct kmem_cache *pwq_cache;
 
 static struct wq_pod_type wq_pod_types[WQ_AFFN_NR_TYPES];
-static enum wq_affn_scope wq_affn_dfl = WQ_AFFN_CACHE;
+static enum wq_affn_scope wq_affn_dfl = WQ_AFFN_CACHE_SHARD;
 
 /* buf for wq_update_unbound_pod_attrs(), protected by CPU hotplug exclusion */
 static struct workqueue_attrs *unbound_wq_update_pwq_attrs_buf;

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -8249,6 +8249,7 @@ static void __init llc_populate_cpu_shard_id(const struct cpumask *pod_cpus,
 	const struct cpumask *sibling_cpus;
 	/* Count the number of cores in the current shard_id */
 	int cores_in_shard = 0;
+	unsigned int leader;
 	/* This is a cursor for the shards. Go from zero to nr_shards - 1*/
 	int shard_id = 0;
 	int c;
@@ -8269,7 +8270,17 @@ static void __init llc_populate_cpu_shard_id(const struct cpumask *pod_cpus,
 			 * The siblings' shard MUST be the same as the leader.
 			 * never split threads in the same core.
 			 */
-			cpu_shard_id[c] = cpu_shard_id[cpumask_first(sibling_cpus)];
+			leader = cpumask_first(sibling_cpus);
+
+			/*
+			 * This check silences a Warray-bounds warning on UP
+			 * configs where NR_CPUS=1 makes cpu_shard_id[]
+			 * a single-element array, and the compiler can't
+			 * prove the index is always 0.
+			 */
+			if (WARN_ON_ONCE(leader >= nr_cpu_ids))
+				continue;
+			cpu_shard_id[c] = cpu_shard_id[leader];
 		}
 	}
 

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -130,6 +130,14 @@ enum wq_internal_consts {
 	WORKER_ID_LEN		= 10 + WQ_NAME_LEN, /* "kworker/R-" + WQ_NAME_LEN */
 };
 
+/* Layout of shards within one LLC pod */
+struct llc_shard_layout {
+	int nr_large_shards;	/* number of large shards (cores_per_shard + 1) */
+	int cores_per_shard;	/* base number of cores per default shard */
+	int nr_shards;		/* total number of shards */
+	/* nr_default shards = (nr_shards - nr_large_shards) */
+};
+
 /*
  * We don't want to trap softirq for too long. See MAX_SOFTIRQ_TIME and
  * MAX_SOFTIRQ_RESTART in kernel/softirq.c. These are macros because
@@ -409,6 +417,7 @@ static const char * const wq_affn_names[WQ_AFFN_NR_TYPES] = {
 	[WQ_AFFN_CPU]		= "cpu",
 	[WQ_AFFN_SMT]		= "smt",
 	[WQ_AFFN_CACHE]		= "cache",
+	[WQ_AFFN_CACHE_SHARD]	= "cache_shard",
 	[WQ_AFFN_NUMA]		= "numa",
 	[WQ_AFFN_SYSTEM]	= "system",
 };
@@ -430,6 +439,9 @@ module_param_named(cpu_intensive_warning_thresh, wq_cpu_intensive_warning_thresh
 /* see the comment above the definition of WQ_POWER_EFFICIENT */
 static bool wq_power_efficient = IS_ENABLED(CONFIG_WQ_POWER_EFFICIENT_DEFAULT);
 module_param_named(power_efficient, wq_power_efficient, bool, 0444);
+
+static unsigned int wq_cache_shard_size = 8;
+module_param_named(cache_shard_size, wq_cache_shard_size, uint, 0444);
 
 static bool wq_online;			/* can kworkers be created yet? */
 static bool wq_topo_initialized __read_mostly = false;
@@ -8138,6 +8150,175 @@ static bool __init cpus_share_numa(int cpu0, int cpu1)
 	return cpu_to_node(cpu0) == cpu_to_node(cpu1);
 }
 
+/* Maps each CPU to its shard index within the LLC pod it belongs to */
+static int cpu_shard_id[NR_CPUS] __initdata;
+
+/**
+ * llc_count_cores - count distinct cores (SMT groups) within an LLC pod
+ * @pod_cpus:  the cpumask of CPUs in the LLC pod
+ * @smt_pods:  the SMT pod type, used to identify sibling groups
+ *
+ * A core is represented by the lowest-numbered CPU in its SMT group. Returns
+ * the number of distinct cores found in @pod_cpus.
+ */
+static int __init llc_count_cores(const struct cpumask *pod_cpus,
+				  struct wq_pod_type *smt_pods)
+{
+	const struct cpumask *sibling_cpus;
+	int nr_cores = 0, c;
+
+	/*
+	 * Count distinct cores by only counting the first CPU in each
+	 * SMT sibling group.
+	 */
+	for_each_cpu(c, pod_cpus) {
+		sibling_cpus = smt_pods->pod_cpus[smt_pods->cpu_pod[c]];
+		if (cpumask_first(sibling_cpus) == c)
+			nr_cores++;
+	}
+
+	return nr_cores;
+}
+
+/*
+ * llc_shard_size - number of cores in a given shard
+ *
+ * Cores are spread as evenly as possible. The first @nr_large_shards shards are
+ * "large shards" with (cores_per_shard + 1) cores; the rest are "default
+ * shards" with cores_per_shard cores.
+ */
+static int __init llc_shard_size(int shard_id, int cores_per_shard, int nr_large_shards)
+{
+	/* The first @nr_large_shards shards are large shards */
+	if (shard_id < nr_large_shards)
+		return cores_per_shard + 1;
+
+	/* The remaining shards are default shards */
+	return cores_per_shard;
+}
+
+/*
+ * llc_calc_shard_layout - compute the shard layout for an LLC pod
+ * @nr_cores:  number of distinct cores in the LLC pod
+ *
+ * Chooses the number of shards that keeps average shard size closest to
+ * wq_cache_shard_size. Returns a struct describing the total number of shards,
+ * the base size of each, and how many are large shards.
+ */
+static struct llc_shard_layout __init llc_calc_shard_layout(int nr_cores)
+{
+	struct llc_shard_layout layout;
+
+	/* Ensure at least one shard; pick the count closest to the target size */
+	layout.nr_shards = max(1, DIV_ROUND_CLOSEST(nr_cores, wq_cache_shard_size));
+	layout.cores_per_shard = nr_cores / layout.nr_shards;
+	layout.nr_large_shards = nr_cores % layout.nr_shards;
+
+	return layout;
+}
+
+/*
+ * llc_shard_is_full - check whether a shard has reached its core capacity
+ * @cores_in_shard: number of cores already assigned to this shard
+ * @shard_id:       index of the shard being checked
+ * @layout:         the shard layout computed by llc_calc_shard_layout()
+ *
+ * Returns true if @cores_in_shard equals the expected size for @shard_id.
+ */
+static bool __init llc_shard_is_full(int cores_in_shard, int shard_id,
+				     const struct llc_shard_layout *layout)
+{
+	return cores_in_shard == llc_shard_size(shard_id, layout->cores_per_shard,
+						layout->nr_large_shards);
+}
+
+/**
+ * llc_populate_cpu_shard_id - populate cpu_shard_id[] for each CPU in an LLC pod
+ * @pod_cpus:  the cpumask of CPUs in the LLC pod
+ * @smt_pods:  the SMT pod type, used to identify sibling groups
+ * @nr_cores:  number of distinct cores in @pod_cpus (from llc_count_cores())
+ *
+ * Walks @pod_cpus in order. At each SMT group leader, advances to the next
+ * shard once the current shard is full. Results are written to cpu_shard_id[].
+ */
+static void __init llc_populate_cpu_shard_id(const struct cpumask *pod_cpus,
+					     struct wq_pod_type *smt_pods,
+					     int nr_cores)
+{
+	struct llc_shard_layout layout = llc_calc_shard_layout(nr_cores);
+	const struct cpumask *sibling_cpus;
+	/* Count the number of cores in the current shard_id */
+	int cores_in_shard = 0;
+	/* This is a cursor for the shards. Go from zero to nr_shards - 1*/
+	int shard_id = 0;
+	int c;
+
+	/* Iterate at every CPU for a given LLC pod, and assign it a shard */
+	for_each_cpu(c, pod_cpus) {
+		sibling_cpus = smt_pods->pod_cpus[smt_pods->cpu_pod[c]];
+		if (cpumask_first(sibling_cpus) == c) {
+			/* This is the CPU leader for the siblings */
+			if (llc_shard_is_full(cores_in_shard, shard_id, &layout)) {
+				shard_id++;
+				cores_in_shard = 0;
+			}
+			cores_in_shard++;
+			cpu_shard_id[c] = shard_id;
+		} else {
+			/*
+			 * The siblings' shard MUST be the same as the leader.
+			 * never split threads in the same core.
+			 */
+			cpu_shard_id[c] = cpu_shard_id[cpumask_first(sibling_cpus)];
+		}
+	}
+
+	WARN_ON_ONCE(shard_id != (layout.nr_shards - 1));
+}
+
+/**
+ * precompute_cache_shard_ids - assign each CPU its shard index within its LLC
+ *
+ * Iterates over all LLC pods. For each pod, counts distinct cores then assigns
+ * shard indices to all CPUs in the pod. Must be called after WQ_AFFN_CACHE and
+ * WQ_AFFN_SMT have been initialized.
+ */
+static void __init precompute_cache_shard_ids(void)
+{
+	struct wq_pod_type *llc_pods = &wq_pod_types[WQ_AFFN_CACHE];
+	struct wq_pod_type *smt_pods = &wq_pod_types[WQ_AFFN_SMT];
+	const struct cpumask *cpus_sharing_llc;
+	int nr_cores;
+	int pod;
+
+	if (!wq_cache_shard_size) {
+		pr_warn("workqueue: cache_shard_size must be > 0, setting to 1\n");
+		wq_cache_shard_size = 1;
+	}
+
+	for (pod = 0; pod < llc_pods->nr_pods; pod++) {
+		cpus_sharing_llc = llc_pods->pod_cpus[pod];
+
+		/* Number of cores in this given LLC */
+		nr_cores = llc_count_cores(cpus_sharing_llc, smt_pods);
+		llc_populate_cpu_shard_id(cpus_sharing_llc, smt_pods, nr_cores);
+	}
+}
+
+/*
+ * cpus_share_cache_shard - test whether two CPUs belong to the same cache shard
+ *
+ * Two CPUs share a cache shard if they are in the same LLC and have the same
+ * shard index. Used as the pod affinity callback for WQ_AFFN_CACHE_SHARD.
+ */
+static bool __init cpus_share_cache_shard(int cpu0, int cpu1)
+{
+	if (!cpus_share_cache(cpu0, cpu1))
+		return false;
+
+	return cpu_shard_id[cpu0] == cpu_shard_id[cpu1];
+}
+
 /**
  * workqueue_init_topology - initialize CPU pods for unbound workqueues
  *
@@ -8153,6 +8334,8 @@ void __init workqueue_init_topology(void)
 	init_pod_type(&wq_pod_types[WQ_AFFN_CPU], cpus_dont_share);
 	init_pod_type(&wq_pod_types[WQ_AFFN_SMT], cpus_share_smt);
 	init_pod_type(&wq_pod_types[WQ_AFFN_CACHE], cpus_share_cache);
+	precompute_cache_shard_ids();
+	init_pod_type(&wq_pod_types[WQ_AFFN_CACHE_SHARD], cpus_share_cache_shard);
 	init_pod_type(&wq_pod_types[WQ_AFFN_NUMA], cpus_share_numa);
 
 	wq_topo_initialized = true;

--- a/kernel/workqueue.c
+++ b/kernel/workqueue.c
@@ -404,7 +404,7 @@ struct work_offq_data {
 	u32			flags;
 };
 
-static const char *wq_affn_names[WQ_AFFN_NR_TYPES] = {
+static const char * const wq_affn_names[WQ_AFFN_NR_TYPES] = {
 	[WQ_AFFN_DFL]		= "default",
 	[WQ_AFFN_CPU]		= "cpu",
 	[WQ_AFFN_SMT]		= "smt",
@@ -7078,13 +7078,7 @@ int workqueue_unbound_housekeeping_update(const struct cpumask *hk)
 
 static int parse_affn_scope(const char *val)
 {
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(wq_affn_names); i++) {
-		if (!strncasecmp(val, wq_affn_names[i], strlen(wq_affn_names[i])))
-			return i;
-	}
-	return -EINVAL;
+	return sysfs_match_string(wq_affn_names, val);
 }
 
 static int wq_affn_dfl_set(const char *val, const struct kernel_param *kp)

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -2628,6 +2628,16 @@ config TEST_VMALLOC
 
 	  If unsure, say N.
 
+config TEST_WORKQUEUE
+	tristate "Test module for stress/performance analysis of workqueue"
+	default n
+	help
+	  This builds the "test_workqueue" module for benchmarking
+	  workqueue throughput under contention. Useful for evaluating
+	  affinity scope changes (e.g., cache_shard vs cache).
+
+	  If unsure, say N.
+
 config TEST_BPF
 	tristate "Test BPF filter functionality"
 	depends on m && NET

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -79,6 +79,7 @@ UBSAN_SANITIZE_test_ubsan.o := y
 obj-$(CONFIG_TEST_KSTRTOX) += test-kstrtox.o
 obj-$(CONFIG_TEST_LKM) += test_module.o
 obj-$(CONFIG_TEST_VMALLOC) += test_vmalloc.o
+obj-$(CONFIG_TEST_WORKQUEUE) += test_workqueue.o
 obj-$(CONFIG_TEST_RHASHTABLE) += test_rhashtable.o
 obj-$(CONFIG_TEST_STATIC_KEYS) += test_static_keys.o
 obj-$(CONFIG_TEST_STATIC_KEYS) += test_static_key_base.o

--- a/lib/test_workqueue.c
+++ b/lib/test_workqueue.c
@@ -242,7 +242,7 @@ static int __init run_bench(int n_threads, const char *scope, const char *label)
 
 	pr_info("test_workqueue:   %-16s %llu items/sec\tp50=%llu\tp90=%llu\tp95=%llu ns\n",
 		label,
-		elapsed_us ? total_items * 1000000ULL / elapsed_us : 0,
+		elapsed_us ? div_u64(total_items * 1000000ULL, elapsed_us) : 0,
 		all_latencies[total_items * 50 / 100],
 		all_latencies[total_items * 90 / 100],
 		all_latencies[total_items * 95 / 100]);

--- a/lib/test_workqueue.c
+++ b/lib/test_workqueue.c
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/*
+ * Test module for stress and performance analysis of workqueue.
+ *
+ * Benchmarks queue_work() throughput on an unbound workqueue to measure
+ * pool->lock contention under different affinity scope configurations
+ * (e.g., cache vs cache_shard).
+ *
+ * The affinity scope is changed between runs via the workqueue's sysfs
+ * affinity_scope attribute (WQ_SYSFS).
+ *
+ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates
+ * Copyright (c) 2026 Breno Leitao <leitao@debian.org>
+ *
+ */
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/workqueue.h>
+#include <linux/kthread.h>
+#include <linux/moduleparam.h>
+#include <linux/completion.h>
+#include <linux/atomic.h>
+#include <linux/slab.h>
+#include <linux/ktime.h>
+#include <linux/cpumask.h>
+#include <linux/sched.h>
+#include <linux/sort.h>
+#include <linux/fs.h>
+
+#define WQ_NAME "bench_wq"
+#define SCOPE_PATH "/sys/bus/workqueue/devices/" WQ_NAME "/affinity_scope"
+
+static int nr_threads;
+module_param(nr_threads, int, 0444);
+MODULE_PARM_DESC(nr_threads,
+		 "Number of threads to spawn (default: 0 = num_online_cpus())");
+
+static int wq_items = 50000;
+module_param(wq_items, int, 0444);
+MODULE_PARM_DESC(wq_items,
+		 "Number of work items each thread queues (default: 50000)");
+
+static struct workqueue_struct *bench_wq;
+static atomic_t threads_done;
+static DECLARE_COMPLETION(start_comp);
+static DECLARE_COMPLETION(all_done_comp);
+
+struct thread_ctx {
+	struct completion work_done;
+	struct work_struct work;
+	u64 *latencies;
+	int cpu;
+	int items;
+};
+
+static void bench_work_fn(struct work_struct *work)
+{
+	struct thread_ctx *ctx = container_of(work, struct thread_ctx, work);
+
+	complete(&ctx->work_done);
+}
+
+static int bench_kthread_fn(void *data)
+{
+	struct thread_ctx *ctx = data;
+	ktime_t t_start, t_end;
+	int i;
+
+	/* Wait for all threads to be ready */
+	wait_for_completion(&start_comp);
+
+	if (kthread_should_stop())
+		return 0;
+
+	for (i = 0; i < ctx->items; i++) {
+		reinit_completion(&ctx->work_done);
+		INIT_WORK(&ctx->work, bench_work_fn);
+
+		t_start = ktime_get();
+		queue_work(bench_wq, &ctx->work);
+		t_end = ktime_get();
+
+		ctx->latencies[i] = ktime_to_ns(ktime_sub(t_end, t_start));
+		wait_for_completion(&ctx->work_done);
+	}
+
+	if (atomic_dec_and_test(&threads_done))
+		complete(&all_done_comp);
+
+	/*
+	 * Wait for kthread_stop() so the module text isn't freed
+	 * while we're still executing.
+	 */
+	while (!kthread_should_stop())
+		schedule();
+
+	return 0;
+}
+
+static int cmp_u64(const void *a, const void *b)
+{
+	u64 va = *(const u64 *)a;
+	u64 vb = *(const u64 *)b;
+
+	if (va < vb)
+		return -1;
+	if (va > vb)
+		return 1;
+	return 0;
+}
+
+static int __init set_affn_scope(const char *scope)
+{
+	struct file *f;
+	loff_t pos = 0;
+	ssize_t ret;
+
+	f = filp_open(SCOPE_PATH, O_WRONLY, 0);
+	if (IS_ERR(f)) {
+		pr_err("test_workqueue: open %s failed: %ld\n",
+		       SCOPE_PATH, PTR_ERR(f));
+		return PTR_ERR(f);
+	}
+
+	ret = kernel_write(f, scope, strlen(scope), &pos);
+	filp_close(f, NULL);
+
+	if (ret < 0) {
+		pr_err("test_workqueue: write '%s' failed: %zd\n", scope, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int __init run_bench(int n_threads, const char *scope, const char *label)
+{
+	struct task_struct **tasks;
+	unsigned long total_items;
+	struct thread_ctx *ctxs;
+	u64 *all_latencies;
+	ktime_t start, end;
+	int cpu, i, j, ret;
+	s64 elapsed_us;
+
+	ret = set_affn_scope(scope);
+	if (ret)
+		return ret;
+
+	ctxs = kcalloc(n_threads, sizeof(*ctxs), GFP_KERNEL);
+	if (!ctxs)
+		return -ENOMEM;
+
+	tasks = kcalloc(n_threads, sizeof(*tasks), GFP_KERNEL);
+	if (!tasks) {
+		kfree(ctxs);
+		return -ENOMEM;
+	}
+
+	total_items = (unsigned long)n_threads * wq_items;
+	all_latencies = kvmalloc_array(total_items, sizeof(u64), GFP_KERNEL);
+	if (!all_latencies) {
+		kfree(tasks);
+		kfree(ctxs);
+		return -ENOMEM;
+	}
+
+	/* Allocate per-thread latency arrays */
+	for (i = 0; i < n_threads; i++) {
+		ctxs[i].latencies = kvmalloc_array(wq_items, sizeof(u64),
+						   GFP_KERNEL);
+		if (!ctxs[i].latencies) {
+			while (--i >= 0)
+				kvfree(ctxs[i].latencies);
+			kvfree(all_latencies);
+			kfree(tasks);
+			kfree(ctxs);
+			return -ENOMEM;
+		}
+	}
+
+	atomic_set(&threads_done, n_threads);
+	reinit_completion(&all_done_comp);
+	reinit_completion(&start_comp);
+
+	/* Create kthreads, each bound to a different online CPU */
+	i = 0;
+	for_each_online_cpu(cpu) {
+		if (i >= n_threads)
+			break;
+
+		ctxs[i].cpu = cpu;
+		ctxs[i].items = wq_items;
+		init_completion(&ctxs[i].work_done);
+
+		tasks[i] = kthread_create(bench_kthread_fn, &ctxs[i],
+					  "wq_bench/%d", cpu);
+		if (IS_ERR(tasks[i])) {
+			ret = PTR_ERR(tasks[i]);
+			pr_err("test_workqueue: failed to create kthread %d: %d\n",
+			       i, ret);
+			/* Unblock threads waiting on start_comp before stopping them */
+			complete_all(&start_comp);
+			while (--i >= 0)
+				kthread_stop(tasks[i]);
+			goto out_free;
+		}
+
+		kthread_bind(tasks[i], cpu);
+		wake_up_process(tasks[i]);
+		i++;
+	}
+
+	/* Start timing and release all threads */
+	start = ktime_get();
+	complete_all(&start_comp);
+
+	/* Wait for all threads to finish the benchmark */
+	wait_for_completion(&all_done_comp);
+
+	/* Drain any remaining work */
+	flush_workqueue(bench_wq);
+
+	/* Ensure all kthreads have fully exited before module memory is freed */
+	for (i = 0; i < n_threads; i++)
+		kthread_stop(tasks[i]);
+
+	end = ktime_get();
+	elapsed_us = ktime_us_delta(end, start);
+
+	/* Merge all per-thread latencies and sort for percentile calculation */
+	j = 0;
+	for (i = 0; i < n_threads; i++) {
+		memcpy(&all_latencies[j], ctxs[i].latencies,
+		       wq_items * sizeof(u64));
+		j += wq_items;
+	}
+
+	sort(all_latencies, total_items, sizeof(u64), cmp_u64, NULL);
+
+	pr_info("test_workqueue:   %-16s %llu items/sec\tp50=%llu\tp90=%llu\tp95=%llu ns\n",
+		label,
+		elapsed_us ? total_items * 1000000ULL / elapsed_us : 0,
+		all_latencies[total_items * 50 / 100],
+		all_latencies[total_items * 90 / 100],
+		all_latencies[total_items * 95 / 100]);
+
+	ret = 0;
+out_free:
+	for (i = 0; i < n_threads; i++)
+		kvfree(ctxs[i].latencies);
+	kvfree(all_latencies);
+	kfree(tasks);
+	kfree(ctxs);
+
+	return ret;
+}
+
+static const char * const bench_scopes[] = {
+	"cpu", "smt", "cache_shard", "cache", "numa", "system",
+};
+
+static int __init test_workqueue_init(void)
+{
+	int n_threads = min(nr_threads ?: num_online_cpus(), num_online_cpus());
+	int i;
+
+	if (wq_items <= 0) {
+		pr_err("test_workqueue: wq_items must be > 0\n");
+		return -EINVAL;
+	}
+
+	bench_wq = alloc_workqueue(WQ_NAME, WQ_UNBOUND | WQ_SYSFS, 0);
+	if (!bench_wq)
+		return -ENOMEM;
+
+	pr_info("test_workqueue: running %d threads, %d items/thread\n",
+		n_threads, wq_items);
+
+	for (i = 0; i < ARRAY_SIZE(bench_scopes); i++)
+		run_bench(n_threads, bench_scopes[i], bench_scopes[i]);
+
+	destroy_workqueue(bench_wq);
+
+	/* Return -EAGAIN so the module doesn't stay loaded after the benchmark */
+	return -EAGAIN;
+}
+
+module_init(test_workqueue_init);
+MODULE_AUTHOR("Breno Leitao <leitao@debian.org>");
+MODULE_DESCRIPTION("Stress/performance benchmark for workqueue subsystem");
+MODULE_LICENSE("GPL");

--- a/tools/workqueue/wq_dump.py
+++ b/tools/workqueue/wq_dump.py
@@ -107,6 +107,7 @@ WQ_MEM_RECLAIM          = prog['WQ_MEM_RECLAIM']
 WQ_AFFN_CPU             = prog['WQ_AFFN_CPU']
 WQ_AFFN_SMT             = prog['WQ_AFFN_SMT']
 WQ_AFFN_CACHE           = prog['WQ_AFFN_CACHE']
+WQ_AFFN_CACHE_SHARD     = prog['WQ_AFFN_CACHE_SHARD']
 WQ_AFFN_NUMA            = prog['WQ_AFFN_NUMA']
 WQ_AFFN_SYSTEM          = prog['WQ_AFFN_SYSTEM']
 
@@ -138,7 +139,7 @@ def print_pod_type(pt):
         print(f' [{cpu}]={pt.cpu_pod[cpu].value_()}', end='')
     print('')
 
-for affn in [WQ_AFFN_CPU, WQ_AFFN_SMT, WQ_AFFN_CACHE, WQ_AFFN_NUMA, WQ_AFFN_SYSTEM]:
+for affn in [WQ_AFFN_CPU, WQ_AFFN_SMT, WQ_AFFN_CACHE, WQ_AFFN_CACHE_SHARD, WQ_AFFN_NUMA, WQ_AFFN_SYSTEM]:
     print('')
     print(f'{wq_affn_names[affn].string_().decode().upper()}{" (default)" if affn == wq_affn_dfl else ""}')
     print_pod_type(wq_pod_types[affn])


### PR DESCRIPTION
## Summary

Set `CONFIG_CMA_SIZE_MBYTES=0` for arm64 linux-nvidia kernels.

This keeps CMA support compiled into the kernel, but stops reserving a default global CMA pool unless one is explicitly requested with the `cma=` kernel command-line option.

## Rationale

The arm64 linux-nvidia kernels previously reserved CMA by default to reduce noisy `cma_alloc()` failures seen during SMMUv3 initialization on large NVIDIA systems. After further testing, the default CMA pool does not appear to be required for the affected paths. The DMA/IOMMU allocation paths that try CMA also have fallback paths through the normal page allocator, and testing confirms that SMMUv3 queue allocation continues to succeed with `cma=0`.

Keeping the default CMA pool has become a liability on larger systems because the pool can still be exhausted, which produces misleading kernel log noise even though the allocation fallback succeeds. There is also no existing knob to keep a default CMA pool while suppressing the failed `cma_alloc()` messages.

Using `CONFIG_CMA_SIZE_MBYTES=0` also aligns the arm64 linux-nvidia default with amd64 behavior and with other enterprise arm64 distro kernels, including RHEL and SLES, which use `CONFIG_CMA_SIZE_MBYTES=0`.

Users that need a default CMA reservation can still opt in with the `cma=` kernel command-line parameter.

## Compatibility

The main user-visible change is that CMA-backed dma-heap nodes are not created by default when there is no default CMA area. For example, with CMA reserved the system exposes:

```text
/dev/dma_heap/default_cma_region
/dev/dma_heap/reserved
/dev/dma_heap/system
```

With `cma=0`, only the generic system heap remains:

```text
/dev/dma_heap/system
```

This is a compatibility consideration for userspace that explicitly opens the CMA-backed heap names. Generic dma-buf system heap users are unaffected.

## Validation

Tested with `cma=0` on linux-nvidia arm64 systems and guests, including 4K and 64K kernel combinations.

Observed behavior:

- kernel command line contains `cma=0`
- dmesg reports `0K cma-reserved`
- `/proc/meminfo` reports `CmaTotal: 0 kB` and `CmaFree: 0 kB`
- no `__cma_alloc` failures
- no DMA pool exhaustion or DMA out-of-memory messages
- SMMUv3 cmdq/evtq/priq allocation succeeds
- atomic DMA pool remains separately preallocated
- `/dev/dma_heap/system` remains present

DGX Spark testing also showed a clean boot with `cma=0`; the only observed dma-heap difference was the expected disappearance of the CMA-backed heap nodes.


LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-7.0/+bug/2149999