### PR TITLE
[26.04_linux-nvidia-bos] NVIDIA: SAUCE: ovl: keep err zero after successful ovl_cache_get()

### DIFF
--- a/fs/overlayfs/readdir.c
+++ b/fs/overlayfs/readdir.c
@@ -838,15 +838,14 @@ static int ovl_iterate_merged(struct file *file, struct dir_context *ctx)
 	struct ovl_dir_file *od = file->private_data;
 	struct dentry *dentry = file->f_path.dentry;
 	struct ovl_cache_entry *p;
-	int err = 0;
+	int err;
 
 	if (!od->cache) {
 		struct ovl_dir_cache *cache;
 
 		cache = ovl_cache_get(dentry);
-		err = PTR_ERR(cache);
 		if (IS_ERR(cache))
-			return err;
+			return PTR_ERR(cache);
 
 		od->cache = cache;
 		ovl_seek_cursor(od, ctx->pos);
@@ -869,7 +868,7 @@ static int ovl_iterate_merged(struct file *file, struct dir_context *ctx)
 		od->cursor = p->l_node.next;
 		ctx->pos++;
 	}
-	return err;
+	return 0;
 }
 
 static bool ovl_need_adjust_d_ino(struct file *file)


### PR DESCRIPTION
## Summary

Fix NVBug 6144764 by keeping `err` zero after a successful `ovl_cache_get()` in `ovl_iterate_merged()`.

The installer crash is an overlayfs readdir failure while rsync reads through overlayfs during BaseOS/DGX OS installation. The bad path is the same as syzbot `a16fb0cce329a320661c`: a successful cache pointer is passed to `PTR_ERR()`, truncating pointer bits into a bogus `int` that can later be returned as a non-errno value.

## Bug Links

- NVBug: https://nvbugspro.nvidia.com/bug/6144764
- Launchpad: https://bugs.launchpad.net/bugs/2150640
- syzbot: https://syzkaller.appspot.com/bug?extid=a16fb0cce329a320661c
- Backported from: https://lore.kernel.org/r/20260514144258.3068715-1-nirmoyd@nvidia.com

## NVBug Evidence

- Symptom: installer can hang/crash while rsync data over overlayfs.
- Reported stack includes `ovl_iterate_merged()` from `getdents64()` on `7.0.0-2005-nvidia-bos`.
- Latest bug comment points to the upstream fix thread and asks for PRs.

## Validation

- Cherry-picked cleanly onto `upstream/26.04_linux-nvidia-bos`.
- `git show --check --format=short HEAD`: clean.
- `scripts/checkpatch.pl --strict --ignore COMMIT_LOG_USE_LINK,COMMIT_LOG_LONG_LINE --git HEAD`: 0 errors, 0 warnings.
- Plain `scripts/checkpatch.pl --strict --git HEAD` warns on Ubuntu `BugLink:` and the long downstream `(backported from ...)` lore URL line.
- Earlier validation on arm64 virtme/KVM KASAN:
  - unpatched / Amir-only controls reproduced the overlayfs crash.
  - patched v2 completed 5/5 runs clean with `OVL_SYZ_DONE rc=0` and no Oops/KASAN/panic markers.

## Notes

The patch is also posted upstream:

- https://lore.kernel.org/r/20260514144258.3068715-1-nirmoyd@nvidia.com
